### PR TITLE
Fix typo and bump Typescript to 4.7 to fix build.

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "typedoc": "0.22.10",
     "typedoc-plugin-missing-exports": "0.22.6",
     "typedoc-plugin-rename-defaults": "0.4.0",
-    "typescript": "4.5.2"
+    "typescript": "4.7"
   },
   "license": "MIT",
   "prettier": {}

--- a/src/kwinscript/driver/window.ts
+++ b/src/kwinscript/driver/window.ts
@@ -294,7 +294,7 @@ export class DriverWindowImpl implements DriverWindow {
     // Using a shorthand name to keep debug message tidy
     var windowIdString = 'undefined'
     if (this.client.windowId) {
-      windowIdStirng = this.client.windowId.toString(16)
+      windowIdString = this.client.windowId.toString(16)
     }
     return `KWin(${windowIdString}.${this.client.resourceClass})`;
   }


### PR DESCRIPTION
Before this, the typo caused a build error (presumably it used to get past before someone decided to ban assigning to undeclared variables) and build also failed with:

```
../../../node_modules/@types/node/events.d.ts(112,43): error TS2370: A rest parameter must be of an array type.
```

The idea to bump typescript came from here:
https://github.com/DefinitelyTyped/DefinitelyTyped/discussions/68895#discussioncomment-8685987
